### PR TITLE
Remove redundant class_name settign in reference model

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -105,7 +105,7 @@ class Reference < ActiveRecord::Base
 
   attr_accessor :display_as, :message
 
-  has_many :products, dependent: :nullify, class_name: "Product", foreign_key: "reference_id"
+  has_many :products, dependent: :nullify, foreign_key: "reference_id"
 
   before_validation :set_defaults
   before_create :set_defaults


### PR DESCRIPTION
## Description
Just a code cleanup, we don't need to specify  the class_name  in the has_many products 
