### PR TITLE
Refactor instance and profile item creation in specs

### DIFF
--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -1,13 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Instance, type: :model do
-  let(:instance) { create(:instance) }
+  let!(:name) { create(:name) }
+  let!(:instance) { create(:instance, name:) }
 
   describe ".product_item_config_id" do
-    let(:name) { create(:name, name_type: instance.name.name_type) }
-    let(:product_item_instance) { create(:instance, name:) }
+    let(:name_type) { create(:name_type) }
+    let(:name2) do
+      n = build(:name, name_type:)
+      n.save(validate: false)
+      n
+    end
+    let(:product_item_instance) { create(:instance, name: name2) }
     let(:product_item_config) { create(:product_item_config) }
-    let!(:profile_item) { create(:profile_item, instance_id: product_item_instance.id, product_item_config: product_item_config) }
+    let!(:profile_item) do
+      create(
+        :profile_item,
+        instance: product_item_instance,
+        instance_id: product_item_instance.id,
+        product_item_config: product_item_config
+      )
+    end
 
     subject { described_class.product_item_config_id(product_item_config.id) }
 
@@ -29,7 +42,7 @@ RSpec.describe Instance, type: :model do
 
   describe "#delete_as_user" do
     let(:instance_type) { create(:instance_type, secondary_instance: false)}
-    let(:instance) { create(:instance, instance_type: instance_type) }
+    let(:instance) { create(:instance, name:, instance_type: instance_type) }
     let(:username) { "test_user" }
 
     context "when deletion is successful" do
@@ -61,7 +74,7 @@ RSpec.describe Instance, type: :model do
   end
 
   describe "#secondary_reference?" do
-    let(:instance) { create(:instance, instance_type: instance_type) }
+    let(:instance) { create(:instance, name:, instance_type: instance_type) }
 
     context "when instance type is not a secondary instance" do
       let(:instance_type) { create(:instance_type, secondary_instance: false)}

--- a/spec/services/profile_items/links/create_service_spec.rb
+++ b/spec/services/profile_items/links/create_service_spec.rb
@@ -59,10 +59,11 @@ RSpec.describe ProfileItems::Links::CreateService, type: :service do
       end
 
       context "when copying a link profile item" do
-        let(:fact_source) do
+        let!(:fact_source) do
           create(
             :profile_item,
             instance_id: instance.id,
+            instance: instance,
             profile_text: profile_text,
             product_item_config: product_item_config,
             statement_type: 'fact',
@@ -70,10 +71,11 @@ RSpec.describe ProfileItems::Links::CreateService, type: :service do
           )
         end
 
-        let(:source_profile_item) do
+        let!(:source_profile_item) do
           create(
             :profile_item,
             instance_id: instance.id,
+            instance: instance,
             product_item_config: product_item_config,
             source_profile_item_id: fact_source.id,
             statement_type: 'link',

--- a/spec/services/profile_items/links/update_service_spec.rb
+++ b/spec/services/profile_items/links/update_service_spec.rb
@@ -1,13 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe ProfileItems::Links::UpdateService, type: :service do
+  let(:name) { create(:name, validate: false) }
   let!(:instance) { create(:instance, name:) }
 
   let(:profile_text) { create(:profile_text) }
   let!(:product_item_config) { create(:product_item_config) }
   let!(:source_profile_item) do
-    build(:profile_item,
+    create(:profile_item,
       instance_id: instance.id,
+      instance: instance,
       product_item_config:,
       profile_text:,
       statement_type: 'fact',
@@ -19,6 +21,7 @@ RSpec.describe ProfileItems::Links::UpdateService, type: :service do
     create(:profile_item,
       product_item_config:,
       instance_id: instance.id,
+      instance: instance,
       profile_text_id: profile_text.id,
       source_profile_item_id: source_profile_item.id,
       statement_type: 'link'
@@ -53,6 +56,7 @@ RSpec.describe ProfileItems::Links::UpdateService, type: :service do
       let!(:source_profile_item) do
         create(:profile_item,
           instance_id: instance.id,
+          instance: instance,
           product_item_config:,
           profile_text:,
           statement_type: 'fact',
@@ -112,6 +116,7 @@ RSpec.describe ProfileItems::Links::UpdateService, type: :service do
       let!(:source_profile_item) do
         create(:profile_item,
           instance_id: instance.id,
+          instance: instance,
           product_item_config:,
           profile_text:,
           statement_type: 'fact',


### PR DESCRIPTION
## Description
This pull request updates several test files to ensure that `ProfileItem` instances are consistently created with both the `instance` and `instance_id` attributes set. This change improves test reliability and aligns test data with the expected model associations.

## Type of change
- [x] Fixup rspec tests

## Tests
- [x] Unit tests
- [ ] Manual testing

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
